### PR TITLE
Paging

### DIFF
--- a/app/app.component.html
+++ b/app/app.component.html
@@ -3,6 +3,7 @@
 	<scc-simple-card-container [data]="items"
 							   [columns]="columns"
 							   [count]="count"
+							   [paging]="true"
 							   [pageNumber]="pageNumber"
 							   (sort)="sort($event)">
 		<div *sccCardContent="let myItem">

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -19,8 +19,8 @@ export class AppComponent {
 	pageNumber = 2;
 	
 	constructor() {
-		const rangeLow: number = 11;
-		const rangeHigh: number = 21;
+		const rangeLow: number = 1;
+		const rangeHigh: number = 101;
 
 		this.items = this.range(rangeLow, rangeHigh).map((num: number): ICardItem => {
 			return {

--- a/lib/container/simpleCardContainer.component.html
+++ b/lib/container/simpleCardContainer.component.html
@@ -17,8 +17,8 @@
 
 			<div class="alert alert-info" *ngIf="message">{{message}}</div>
 
-			<div *ngIf="data != null">
-				<div class="card-item-repeat" *ngFor="let card of data">
+			<div *ngIf="processedData != null">
+				<div class="card-item-repeat" *ngFor="let card of processedData">
 					<scc-card [item]="card"
 							  [isOpen]="card === openCard"
 							  (open)="openCard = $event"
@@ -31,9 +31,9 @@
 					<template [ngTemplateOutlet]="containerFooter.template"></template>
 				</div>
 				<div class="row" *ngIf="!containerFooter">
-					<div class="col-sm-5"><p>Showing <strong>{{data.length}} of {{totalItems}}</strong> total items</p></div>
+					<div class="col-sm-5"><p>Showing <strong>{{processedData.length}} of {{totalItems}}</strong> total items</p></div>
 					<div class="col-sm-7"><scc-pager [totalCount]="totalItems"
-													 [pageSize]="data.length"
+													 [pageSize]="pageSize"
 													 [pageNumber]="pageNumber"
 													 (pageNumberChange)="setPage($event)"></scc-pager></div>
 				</div>

--- a/lib/container/simpleCardContainer.component.spec.ts
+++ b/lib/container/simpleCardContainer.component.spec.ts
@@ -1,0 +1,106 @@
+import { SimpleCardContainerComponent, defaultPageSize } from './simpleCardContainer.component';
+
+interface PagingServiceMock {
+	filter: sinon.SinonSpy;
+}
+
+describe('SimpleCardContainerComponent', () => {
+	let component: SimpleCardContainerComponent<number>;
+	let pagingService: any;
+
+	beforeEach(() => {
+		pagingService = {
+			filter: sinon.spy(data => data),
+		};
+		component = new SimpleCardContainerComponent<number>(<any>pagingService);
+	});
+
+	describe('ngOnInit', () => {
+		it('should default the page number and page size', () => {
+			component.ngOnInit();
+
+			expect(component.pageNumber).to.equal(1);
+			expect(component.pageSize).to.equal(defaultPageSize);
+		});
+
+		it('should allow the consumer to set a custom page number and page size', () => {
+			const pageNumber = 3;
+			const pageSize = 20;
+			component.pageNumber = pageNumber;
+			component.pageSize = pageSize;
+
+			component.ngOnInit();
+
+			expect(component.pageNumber).to.equal(pageNumber);
+			expect(component.pageSize).to.equal(pageSize);
+		});
+		
+		it('should not setup the paging service as a data filter by default', () => {
+			component.ngOnInit();
+			sinon.assert.notCalled(pagingService.filter);
+		});
+
+		it('should setup the paging service as a data filter if paging is enabled', () => {
+			component.paging = true;
+			component.data = [1, 2];
+			
+			component.ngOnInit();
+
+			sinon.assert.calledOnce(pagingService.filter);
+			sinon.assert.calledWith(pagingService.filter, component.data, component.pageNumber, component.pageSize);
+		});
+	});
+
+	describe('setPage', () => {
+		it('should update the page number and emit a paging event', () => {
+			const pageSpy = sinon.spy();
+			component.page.subscribe(pageSpy)
+			component.pageNumber = 1;
+			component.pageSize = 10;
+
+			component.setPage(3);
+
+			expect(component.pageNumber).to.equal(3);
+			sinon.assert.calledOnce(pageSpy);
+			sinon.assert.calledWith(pageSpy, {
+				pageSize: component.pageSize,
+				pageNumber: 3,
+			});
+		});
+	});
+
+	describe('process', () => {
+		it('should process when the data is set', () => {
+			const processSpy = sinon.spy(() => [3, 4]);
+			component.process = processSpy;
+
+			component.data = [1, 2, 3, 4];
+
+			sinon.assert.calledOnce(processSpy);
+			expect(component.data).to.deep.equal([1, 2, 3, 4]);
+			expect(component.processedData).to.deep.equal([3, 4]);
+		});
+
+		it('should process on init', () => {
+			component.data = [1, 2, 3, 4];
+			const processSpy = sinon.spy(() => [3, 4]);
+			component.process = processSpy;
+
+			component.ngOnInit();
+
+			sinon.assert.calledOnce(processSpy);
+			expect(component.processedData).to.deep.equal([3, 4]);
+		});
+
+		it('should process on a page change', () => {
+			component.data = [1, 2, 3, 4];
+			const processSpy = sinon.spy(() => [3, 4]);
+			component.process = processSpy;
+
+			component.setPage(1);
+
+			sinon.assert.calledOnce(processSpy);
+			expect(component.processedData).to.deep.equal([3, 4]);
+		});
+	});
+});

--- a/lib/container/simpleCardContainer.component.ts
+++ b/lib/container/simpleCardContainer.component.ts
@@ -1,7 +1,11 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ContentChild } from '@angular/core';
+import { reduce } from 'lodash';
 
 import { IColumn, IPage } from '../interfaces';
 import { CardContentTemplate, CardFooterTemplate, ContainerHeaderTemplate, ContainerFooterTemplate } from '../templates';
+import { PagingService } from '../services/paging.service';
+
+export const defaultPageSize: number = 10;
 
 @Component({
 	selector: 'scc-simple-card-container',
@@ -10,10 +14,21 @@ import { CardContentTemplate, CardFooterTemplate, ContainerHeaderTemplate, Conta
 })
 export class SimpleCardContainerComponent<T> {
 	@Input() columns: IColumn<T>[];
-	@Input() data: T[];
 	@Input() count: number;
 	@Input() pageNumber: number;
+	@Input() pageSize: number;
 	@Input() message: string;
+	@Input() paging: boolean;
+	
+	private _data: T[];
+	@Input() set data(value: T[]) {
+		this._data = value;
+		this.processedData = this.process(value);
+	}
+
+	get data(): T[] {
+		return this._data;
+	}
 
 	get totalItems(): number {
 		return this.count || this.data.length;
@@ -27,12 +42,36 @@ export class SimpleCardContainerComponent<T> {
 	@ContentChild(ContainerHeaderTemplate) containerHeader: ContainerHeaderTemplate;
 	@ContentChild(ContainerFooterTemplate) containerFooter: ContainerFooterTemplate;
 
+	processedData: T[];
 	openCard: T;
 
+	private dataFilters: { (data: T[]): T[] }[];
+
+	constructor(private pagingService: PagingService) {}
+
+	ngOnInit(): void {
+		this.pageNumber = this.pageNumber || 1;
+		this.pageSize = this.pageSize || defaultPageSize;
+
+		this.dataFilters = [];
+
+		if (this.paging) {
+			this.dataFilters.push(data => this.pagingService.filter(data, this.pageNumber, this.pageSize));
+		}
+
+		this.processedData = this.process(this.data);
+	}
+
 	setPage(pageNumber: number): void {
+		this.pageNumber = pageNumber;
+		this.processedData = this.process(this.data);
 		this.page.emit({
-			pageSize: this.data.length,
+			pageSize: this.pageSize,
 			pageNumber,
 		});
+	}
+
+	process(dataSet: T[]): T[] {
+		return reduce(this.dataFilters, (data, filter) => filter(data), dataSet);
 	}
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,3 +3,4 @@ export * from './interfaces';
 export * from './sortDirection';
 export * from './templates';
 export * from './container/simpleCardContainer.component';
+export * from './services/paging.service';

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -7,6 +7,7 @@ import { ColumnHeaderComponent } from './header/columnHeader.component';
 import { CardHeaderColumnComponent } from './header/cardHeaderColumn.component';
 import { CardComponent } from './card/card.component';
 import { PagerComponent } from './pager/pager.component';
+import { PagingService } from './services/paging.service';
 import { TEMPLATE_DIRECTIVES } from './templates';
 
 @NgModule({
@@ -28,6 +29,7 @@ import { TEMPLATE_DIRECTIVES } from './templates';
 	],
 	providers: [
 		BreakpointSizesService,
+		PagingService,
 	],
 })
 export class SimpleCardContainerModule {}

--- a/lib/services/paging.service.spec.ts
+++ b/lib/services/paging.service.spec.ts
@@ -1,0 +1,46 @@
+import { PagingService, startFrom } from './paging.service';
+
+describe('PagingService', () => {
+	let paging: PagingService;
+
+	beforeEach(() => {
+		paging = new PagingService();
+	});
+
+	it('should restrict data set to page size', (): void => {
+		const pageNumber = 1;
+		const pageSize = 2;
+
+		const result: number[] = paging.filter([1, 2, 3, 4], pageNumber, pageSize);
+
+		expect(result).to.deep.equal([1, 2]);
+	});
+
+	it('should skip to indicated page', (): void => {
+		const pageNumber = 3;
+		const pageSize = 1;
+
+		const result: number[] = paging.filter([1, 2, 3, 4], pageNumber, pageSize);
+
+		expect(result).to.deep.equal([3]);
+	});
+
+	it('should be empty if page goes past the end', (): void => {
+		const pageNumber = 2;
+		const pageSize = 8;
+
+		const result: number[] = paging.filter([1, 2, 3, 4], pageNumber, pageSize);
+		
+		expect(result).to.be.empty;
+	});
+
+	describe('startFrom', () => {
+		it('should start from 0 on the first page', () => {
+			expect(startFrom(1, 3)).to.equal(0);
+		});
+
+		it('should increment by the page size', () => {
+			expect(startFrom(2, 3)).to.equal(3);
+		});
+	});
+});

--- a/lib/services/paging.service.ts
+++ b/lib/services/paging.service.ts
@@ -1,0 +1,11 @@
+import { drop, take } from 'lodash';
+
+export class PagingService {
+	filter<T>(dataSet: T[], pageNumber: number, pageSize: number): T[] {
+		return take(drop(dataSet, startFrom(pageNumber, pageSize)), pageSize);
+	}
+}
+
+export function startFrom(pageNumber: number, pageSize: number): number {
+	return (pageNumber - 1) * pageSize;
+}


### PR DESCRIPTION
Implement a default paging service for the simple card container. This will be applied to filter the data that is provided if the paging option is set to true. The pager is just a pure function that takes a page number and page size, and applies them as a filter on the data. I'm implementing this in such a way that it would be easy to add additional 'filters' to the card container, such as for sorting.